### PR TITLE
Port core MATLAB scripts to Python

### DIFF
--- a/ERM_fDR_CNN.py
+++ b/ERM_fDR_CNN.py
@@ -1,0 +1,101 @@
+import numpy as np
+import scipy.io as sio
+from elu_fast import elu_fast
+
+def formatdata(data):
+    n_samples = data.shape[0]
+    labels = data[:n_samples, 0].astype(int)
+    y = np.zeros((10, n_samples))
+    y[labels, np.arange(n_samples)] = 1
+    x = data[:n_samples, 1:785] / 255.0
+    return x, y
+
+def empiricalrisk(model, x, y):
+    x = x.T
+    w2, b2, w3, b3, w4, b4 = model
+    out2 = elu_fast(w2 @ x + b2)
+    out3 = elu_fast(w3 @ out2 + b3)
+    out = elu_fast(w4 @ out3 + b4)
+    pred = np.argmax(out, axis=0)
+    loss = np.sum(pred != y)
+    return loss / x.shape[1]
+
+def cnvxmodels(m1, m2, m3, m4, Cx):
+    return [
+        Cx[0]*m1[0] + Cx[1]*m2[0] + Cx[2]*m3[0] + Cx[3]*m4[0],
+        Cx[0]*m1[1] + Cx[1]*m2[1] + Cx[2]*m3[1] + Cx[3]*m4[1],
+        Cx[0]*m1[2] + Cx[1]*m2[2] + Cx[2]*m3[2] + Cx[3]*m4[2],
+        Cx[0]*m1[3] + Cx[1]*m2[3] + Cx[2]*m3[3] + Cx[3]*m4[3],
+        Cx[0]*m1[4] + Cx[1]*m2[4] + Cx[2]*m3[4] + Cx[3]*m4[4],
+        Cx[0]*m1[5] + Cx[1]*m2[5] + Cx[2]*m3[5] + Cx[3]*m4[5],
+    ]
+
+def main():
+    batch = 1
+    n_sampl = 100
+    per = 2/3
+    perts = 2/3
+
+    data_tr = np.loadtxt('mnist_train.csv', delimiter=',')
+    data_ts = np.loadtxt('mnist_test.csv', delimiter=',')
+    Xtr, _ = formatdata(data_tr)
+    Xts, _ = formatdata(data_ts)
+    Ytr = data_tr[:, 0].astype(int)
+    Yts = data_ts[:, 0].astype(int)
+
+    n_samples = Xtr.shape[0]
+    n_smap_ts = Xts.shape[0]
+
+    m1 = sio.loadmat('Models/model2.mat')
+    m2 = sio.loadmat('Models/model3.mat')
+    m3 = sio.loadmat('Models/model4.mat')
+    m4 = sio.loadmat('Models/model5.mat')
+    Cx = sio.loadmat('Models/convex_short_220.mat')['Cx']
+
+    M1 = [m1['w12'], m1['b12'], m1['w23'], m1['b23'], m1['w34'], m1['b34']]
+    M2 = [m2['w12'], m2['b12'], m2['w23'], m2['b23'], m2['w34'], m2['b34']]
+    M3 = [m3['w12'], m3['b12'], m3['w23'], m3['b23'], m3['w34'], m3['b34']]
+    M4 = [m4['w12'], m4['b12'], m4['w23'], m4['b23'], m4['w34'], m4['b34']]
+
+    k = Cx.shape[0]
+    rng = np.random.default_rng(1)
+    indx = rng.choice(n_samples, size=round(n_samples*per), replace=False)
+    indxts = rng.choice(n_smap_ts, size=round(n_smap_ts*perts), replace=False)
+    Z1x = Xtr[indx]
+    Z1y = Ytr[indx]
+    Z2x = Xts[indxts]
+    Z2y = Yts[indxts]
+
+    Lz1 = np.zeros(k)
+    Lz2 = np.zeros(k)
+    for i in range(k):
+        m = cnvxmodels(M1, M2, M3, M4, Cx[i])
+        Lz1[i] = empiricalrisk(m, Z1x, Z1y)
+        Lz2[i] = empiricalrisk(m, Z2x, Z2y)
+
+    Qpdf = np.ones(k) / k
+    dQ = Qpdf
+
+    lamb = np.logspace(-3, 2, n_sampl)
+    bt1z1 = np.zeros(n_sampl)
+    Rz1p1z1 = np.zeros(n_sampl)
+    Rz2p1z1 = np.zeros(n_sampl)
+
+    Lz1dQ = Lz1 * dQ
+    Lz2dQ = Lz2 * dQ
+
+    for i in range(n_sampl):
+        lambda_ = lamb[i]
+        P1_z1 = np.exp(-Lz1 / lambda_) * dQ
+        P1_z1 = P1_z1 / np.sum(P1_z1)
+        bt1z1[i] = -lambda_ + lambda_ * np.log(np.sum(np.exp(-Lz1 / lambda_) * dQ))
+        Rz1p1z1[i] = np.sum(Lz1dQ * P1_z1)
+        Rz2p1z1[i] = np.sum(Lz2dQ * P1_z1)
+
+    GpT1 = np.abs(Rz2p1z1 - Rz1p1z1)
+    RzT1 = np.column_stack([Rz1p1z1, Rz2p1z1])
+    results = {'GpT1': GpT1, 'RzT1': RzT1, 'NQzT1': bt1z1, 'lamb': lamb}
+    return results
+
+if __name__ == '__main__':
+    main()

--- a/MatrixInterpolation.py
+++ b/MatrixInterpolation.py
@@ -1,0 +1,29 @@
+import numpy as np
+import scipy.io as sio
+
+def matrix_interpolation():
+    """Interpolate between four models via convex combinations."""
+    m1 = sio.loadmat('model2.mat')
+    m2 = sio.loadmat('model3.mat')
+    m3 = sio.loadmat('model4.mat')
+    m4 = sio.loadmat('model5.mat')
+
+    res = 10
+    tolerance = 1e-10
+    inter = np.linspace(0, 1, res)
+    A, B, C, D = np.meshgrid(inter, inter, inter, inter, indexing='ij')
+    cone = np.column_stack([A.ravel(), B.ravel(), C.ravel(), D.ravel()])
+    Cx = cone[np.abs(cone.sum(axis=1) - 1) < tolerance]
+
+    Cell_m = []
+    for coeffs in Cx:
+        c1, c2, c3, c4 = coeffs
+        Cell_m.append([
+            c1*m1['w12'] + c2*m2['w12'] + c3*m3['w12'] + c4*m4['w12'],
+            c1*m1['b12'] + c2*m2['b12'] + c3*m3['b12'] + c4*m4['b12'],
+            c1*m1['w23'] + c2*m2['w23'] + c3*m3['w23'] + c4*m4['w23'],
+            c1*m1['b23'] + c2*m2['b23'] + c3*m3['b23'] + c4*m4['b23'],
+            c1*m1['w34'] + c2*m2['w34'] + c3*m3['w34'] + c4*m4['w34'],
+            c1*m1['b34'] + c2*m2['b34'] + c3*m3['b34'] + c4*m4['b34'],
+        ])
+    return Cell_m, Cx

--- a/digit_test.py
+++ b/digit_test.py
@@ -1,0 +1,25 @@
+import numpy as np
+import scipy.io as sio
+from elu import elu
+
+def digit_test():
+    test = np.loadtxt('mnist_test.csv', delimiter=',')
+    labels = test[:, 0].astype(int)
+    images = test[:, 1:785] / 255.0
+    images = images.T
+    model = sio.loadmat('model5.mat')
+    w4, w3, w2 = model['w34'], model['w23'], model['w12']
+    b4, b3, b2 = model['b34'], model['b23'], model['b12']
+    success = 0
+    n = images.shape[1]
+    for i in range(n):
+        out2 = elu(w2 @ images[:, i:i+1] + b2)
+        out3 = elu(w3 @ out2 + b3)
+        out = elu(w4 @ out3 + b4)
+        num = np.argmax(out)
+        if labels[i] == num:
+            success += 1
+    print('Accuracy:', success / n * 100, '%')
+
+if __name__ == '__main__':
+    digit_test()

--- a/digit_train.py
+++ b/digit_train.py
@@ -1,0 +1,73 @@
+import numpy as np
+import scipy.io as sio
+from elu import elu
+from elup import elup
+from shuffle import shuffle
+
+def digit_train():
+    data = np.loadtxt('mnist_train.csv', delimiter=',')
+    n_samples = 5000
+    labels = data[:n_samples, 0].astype(int)
+    y = np.zeros((10, n_samples))
+    y[labels, np.arange(n_samples)] = 1
+    images = data[:n_samples, 1:] / 255.0
+    images = images.T
+
+    hn1 = 80
+    hn2 = 60
+    epochs = 5
+    m = 10
+
+    w12 = np.random.randn(hn1, 784) * np.sqrt(2 / 784)
+    w23 = np.random.randn(hn2, hn1) * np.sqrt(2 / hn1)
+    w34 = np.random.randn(10, hn2) * np.sqrt(2 / hn2)
+    b12 = np.random.randn(hn1, 1)
+    b23 = np.random.randn(hn2, 1)
+    b34 = np.random.randn(10, 1)
+    eta = 0.0158
+
+    for k in range(epochs):
+        batches = 0
+        for _ in range(n_samples // m):
+            errortot4 = np.zeros((10, 1))
+            errortot3 = np.zeros((hn2, 1))
+            errortot2 = np.zeros((hn1, 1))
+            grad4 = np.zeros((10, hn2))
+            grad3 = np.zeros((hn2, hn1))
+            grad2 = np.zeros((hn1, 784))
+
+            for i in range(batches, batches + m):
+                a1 = images[:, i:i+1]
+                z2 = w12 @ a1 + b12
+                a2 = elu(z2)
+                z3 = w23 @ a2 + b23
+                a3 = elu(z3)
+                z4 = w34 @ a3 + b34
+                a4 = elu(z4)
+
+                error4 = (a4 - y[:, i:i+1]) * elup(z4)
+                error3 = (w34.T @ error4) * elup(z3)
+                error2 = (w23.T @ error3) * elup(z2)
+
+                errortot4 += error4
+                errortot3 += error3
+                errortot2 += error2
+                grad4 += error4 @ a3.T
+                grad3 += error3 @ a2.T
+                grad2 += error2 @ a1.T
+
+            w34 -= eta / m * grad4
+            w23 -= eta / m * grad3
+            w12 -= eta / m * grad2
+            b34 -= eta / m * errortot4
+            b23 -= eta / m * errortot3
+            b12 -= eta / m * errortot2
+            batches += m
+        print('Epochs:', k + 1)
+        images, y = shuffle(images, y)
+
+    print('Training done!')
+    sio.savemat('model5.mat', {'w12': w12, 'w23': w23, 'w34': w34, 'b12': b12, 'b23': b23, 'b34': b34})
+
+if __name__ == '__main__':
+    digit_train()

--- a/elu.py
+++ b/elu.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+def elu(x):
+    """Exponential linear unit activation.
+
+    Parameters
+    ----------
+    x : array_like
+        Input array.
+
+    Returns
+    -------
+    ndarray
+        Elementwise ELU activation where negative values are scaled by 0.2.
+    """
+    x = np.asarray(x)
+    return np.where(x >= 0, x, 0.2 * (np.exp(x) - 1))

--- a/elu_fast.py
+++ b/elu_fast.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+def elu_fast(x):
+    """Vectorised exponential linear unit activation."""
+    x = np.asarray(x)
+    result = np.zeros_like(x)
+    mask = x >= 0
+    result[mask] = x[mask]
+    result[~mask] = 0.2 * (np.exp(x[~mask]) - 1)
+    return result

--- a/elup.py
+++ b/elup.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+def elup(x):
+    """Derivative of the ELU activation."""
+    x = np.asarray(x)
+    return np.where(x >= 0, 1.0, 0.2 * np.exp(x))

--- a/findbetaf.py
+++ b/findbetaf.py
@@ -1,0 +1,76 @@
+import numpy as np
+
+def findbetaf(Lz, Integral, lambd, dP, name, n=10):
+    """Find beta such that the integral of dP equals one."""
+    supp = Integral == 0
+    minlz = np.min(np.where(supp, np.inf, Lz))
+    lgm = 0.0
+    ibeta = 0.0
+    if name == 'Type1':
+        raise ValueError('No need for findbeta for Type1')
+    elif name == 'Type2':
+        if minlz == 0:
+            minlz = -1e-8
+        r = np.floor(np.log10(np.abs(minlz)))
+        res = r - 2
+        mnbeta = -minlz
+        mxbeta = lambd
+    elif name == 'JSerm':
+        b = -minlz + lambd * np.log(0.5)
+        r = np.floor(np.log10(np.abs(b)))
+        bv = np.arange(b - 10**(r-1), b + 10**(r-1) + 10**(r-6), 10**(r-6))
+        idx = np.argmax(dP(minlz, lambd, bv))
+        res = r - 4
+        mnbeta = bv[idx]
+        mxbeta = lambd
+    elif name == 'Hell':
+        r = np.floor(np.log10(np.abs(-minlz - lambd)))
+        res = r - 4
+        mnbeta = -minlz - lambd
+        mxbeta = lambd
+    else:
+        raise ValueError('Unknown name')
+
+    val = np.sum(dP(Lz, lambd, mnbeta + 10**res) * Integral)
+    while np.isnan(val) or val <= 1 or val == np.inf:
+        mxbeta = mnbeta + 10**res
+        val = np.sum(dP(Lz, lambd, mnbeta + 10**(res-1)) * Integral)
+        if val == np.inf:
+            res += 0.6
+        elif res < -1000:
+            mnbeta = mnbeta / 10
+        else:
+            res -= 1
+        if res == -np.inf:
+            raise RuntimeError('Error finding beta')
+    val = np.sum(dP(Lz, lambd, mxbeta) * Integral)
+    while val > 1:
+        mxbeta = mnbeta + 10**r
+        val = np.sum(dP(Lz, lambd, mxbeta) * Integral)
+        if mxbeta > 1000:
+            raise RuntimeError('Error finding beta')
+
+    iter_count = 1
+    lgm = np.linspace(mnbeta, mxbeta, n)
+    tt = np.zeros_like(lgm)
+    for _ in range(1000000):
+        for i in range(len(lgm)):
+            tt[i] = np.sum(dP(Lz, lambd, lgm[i]) * Integral)
+        idx = np.argmin(np.abs(tt - 1))
+        if idx == 0 and tt[0] < 1 or idx == n-1 and tt[-1] > 1:
+            raise RuntimeError('Error finding beta')
+        if idx == 0:
+            idx = 1
+        elif idx == n-1:
+            idx = n-2
+        mxbeta = lgm[idx+1]
+        mnbeta = lgm[idx-1]
+        ibeta = tt[idx]
+        if abs(1 - ibeta) <= 1e-5:
+            break
+        lgm = np.linspace(mnbeta, mxbeta, n)
+    beta = lgm[idx]
+    check = np.min(dP(Lz, lambd, beta) * (~supp))
+    if iter_count > 1000000 or check < 0:
+        raise RuntimeError('Error finding beta loop')
+    return beta

--- a/shuffle.py
+++ b/shuffle.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+def shuffle(A, y):
+    """Shuffle columns of A and corresponding labels y."""
+    cols = A.shape[1]
+    P = np.random.permutation(cols)
+    return A[:, P], y[:, P]


### PR DESCRIPTION
## Summary
- Add Python equivalents of ELU activation functions and utility shuffle
- Translate training/testing scripts and ERM evaluation to Python
- Provide helper to interpolate among models and compute beta parameter

## Testing
- `python -m compileall elu.py elu_fast.py elup.py shuffle.py MatrixInterpolation.py findbetaf.py digit_train.py digit_test.py ERM_fDR_CNN.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac2b8ae0bc8326b65407d1322d6a67